### PR TITLE
Bypass presence validation in comparison validator if it has already been checked.

### DIFF
--- a/activemodel/lib/active_model/validations/comparison.rb
+++ b/activemodel/lib/active_model/validations/comparison.rb
@@ -20,8 +20,11 @@ module ActiveModel
         options.slice(*COMPARE_CHECKS.keys).each do |option, raw_option_value|
           option_value = resolve_value(record, raw_option_value)
 
-          if value.nil? || value.blank?
-            return record.errors.add(attr_name, :blank, **error_options(value, option_value))
+          if value.blank?
+            unless record.errors.added?(attr_name, :blank)
+              record.errors.add(attr_name, :blank, **error_options(value, option_value))
+            end
+            return
           end
 
           unless value.public_send(COMPARE_CHECKS[option], option_value)

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -453,4 +453,20 @@ class ValidationsTest < ActiveModel::TestCase
     assert_predicate t, :invalid?
     assert_equal ["Title is missing. You have failed me for the last time, Admiral."], t.errors[:title]
   end
+
+  def test_comparison_validator_bypasses_check_for_presence_if_already_checked_before
+    Topic.validates :price, presence: true, comparison: { greater_than: 0 }
+    t = Topic.new
+
+    assert_predicate t, :invalid?
+    assert_equal ["can't be blank"], t.errors[:price]
+  end
+
+  def test_comparison_validator_checks_for_presence_if_not_already_checked_before
+    Topic.validates :price, comparison: { greater_than: 0 }
+    t = Topic.new
+
+    assert_predicate t, :invalid?
+    assert_equal ["can't be blank"], t.errors[:price]
+  end
 end


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Fixes #52243

Currently, the `validate_each` method in `ComparisonValidator` checks for presence and add an error to the record object.

However, for the following case, 
```ruby
validates :attribute, presence: true, comparison: { greater_than: 0 }
```

this would cause the error to be added twice - once by the `Validations::PresenceValidator` and then by `Validations::ComparisonValidator`.


### Detail
- In `ComparisonValidator#validates_each`, added a condition to not check for presence twice.

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
